### PR TITLE
Update to Ghidra Version 10.0.4_PUBLIC

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM openjdk:11-jdk-slim
 
-ENV VERSION 10.0.4_PUBLIC
-ENV DL https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_10.0.4_build/ghidra_${VERSION}_20210928.zip
-ENV GHIDRA_SHA 1ce9bdf2d7f6bdfe5dccd06da828af31bc74acfd800f71ade021d5211e820d5e
+ENV VERSION 10.1.3_PUBLIC
+ENV DL https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_10.1.3_build/ghidra_10.1.3_PUBLIC_20220421.zip
+ENV GHIDRA_SHA 9c73b6657413686c0af85909c20581e764107add2a789038ebc6eca49dc4e812
 
 RUN apt-get update && apt-get install -y wget unzip dnsutils --no-install-recommends \
     && wget --progress=bar:force -O /tmp/ghidra.zip ${DL} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM openjdk:11-jdk-slim
 
-ENV VERSION 9.2_PUBLIC
-ENV DL https://www.ghidra-sre.org/ghidra_${VERSION}_20201113.zip
-ENV GHIDRA_SHA ffebd3d87bc7c6d9ae1766dd3293d1fdab3232a99b170f8ea8b57497a1704ff6
+ENV VERSION 10.0.4_PUBLIC
+ENV DL https://www.ghidra-sre.org/ghidra_${VERSION}_20210928.zip
+ENV GHIDRA_SHA 1ce9bdf2d7f6bdfe5dccd06da828af31bc74acfd800f71ade021d5211e820d5e
 
 RUN apt-get update && apt-get install -y wget unzip dnsutils --no-install-recommends \
     && wget --progress=bar:force -O /tmp/ghidra.zip ${DL} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM openjdk:11-jdk-slim
 
 ENV VERSION 10.0.4_PUBLIC
-ENV DL https://www.ghidra-sre.org/ghidra_${VERSION}_20210928.zip
+ENV DL https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_10.0.4_build/ghidra_${VERSION}_20210928.zip
 ENV GHIDRA_SHA 1ce9bdf2d7f6bdfe5dccd06da828af31bc74acfd800f71ade021d5211e820d5e
 
 RUN apt-get update && apt-get install -y wget unzip dnsutils --no-install-recommends \


### PR DESCRIPTION
Image builds. Unsure about whether projects can be migrated from old versions of the server and still work, but I ran this new docker container with the same `/repos` folder and users and passwords were preserved across version change. 