### PR TITLE
Update to Ghidra 10.2.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM openjdk:11-jdk-slim
+FROM openjdk:17-jdk-slim
 
-ENV VERSION 10.1.5_PUBLIC
-ENV DL https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_10.1.5_build/ghidra_10.1.5_PUBLIC_20220726.zip
-ENV GHIDRA_SHA 17db4ba7d411d11b00d1638f163ab5d61ef38712cd68e462eb8c855ec5cfb5ed
+ENV VERSION 10.2.2_PUBLIC
+ENV DL https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_10.2.2_build/ghidra_10.2.2_PUBLIC_20221115.zip
+ENV GHIDRA_SHA feb8a795696b406ad075e2c554c80c7ee7dd55f0952458f694ea1a918aa20ee3
 
 RUN apt-get update && apt-get install -y wget unzip dnsutils --no-install-recommends \
     && wget --progress=bar:force -O /tmp/ghidra.zip ${DL} \


### PR DESCRIPTION
This PR updates Ghidra to 10.2.2 and the base image to the required JDK version 17.
I have already published an image at https://github.com/enlyze/docker-ghidra-server/pkgs/container/ghidra-server and I'm using it successfully, but would like to see these changes going upstream.