### PR TITLE
Allow listening on custom interfaces

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,7 +17,7 @@ if [ "$1" = 'server' ]; then
     done
   fi
 
-  exec "/ghidra/server/ghidraSvr" console
+  exec "/ghidra/server/ghidraSvr" console ${GHIDRA_PUBLIC_INTERFACE:=""}
 fi
 
 exec "$@"


### PR DESCRIPTION
By supplying something like `-i lo` or `-i ens1` it is possible to listen only on specific interfaces