### PR TITLE
Rebase to jdk 21

### DIFF
--- a/Dockerfile.beta
+++ b/Dockerfile.beta
@@ -10,7 +10,7 @@ RUN echo "[+] Cloning Ghidra..." \
 WORKDIR /root/git/ghidra
 
 RUN echo "[+] Downloading dependencies..." \
-    && gradle --init-script gradle/support/fetchDependencies.gradle init
+    && gradle --init-script gradle/support/fetchDependencies.gradle init --overwrite
 
 RUN echo "[+] Building Ghidra..." \
     && gradle buildNatives_linux64 \

--- a/Dockerfile.beta
+++ b/Dockerfile.beta
@@ -2,7 +2,7 @@ FROM gradle:jdk17 as builder
 
 ENV GITHUB_URL https://github.com/NationalSecurityAgency/ghidra.git
 
-RUN apt-get update && apt-get install -y curl git bison flex build-essential unzip
+RUN apt-get update && apt-get install -y curl git bison flex build-essential unzip python3-pip
 
 RUN echo "[+] Cloning Ghidra..." \
     && git clone ${GITHUB_URL} /root/git/ghidra

--- a/Dockerfile.beta
+++ b/Dockerfile.beta
@@ -1,4 +1,4 @@
-FROM gradle:jdk17 as builder
+FROM gradle:jdk21 as builder
 
 ENV GITHUB_URL https://github.com/NationalSecurityAgency/ghidra.git
 
@@ -26,7 +26,7 @@ RUN echo "[+] Unzip Ghidra..." \
     && rm -rf /ghidra/docs /ghidra/Extensions/Eclipse /ghidra/licenses
 
 ##########################################################################################
-FROM openjdk:17-jdk-slim
+FROM openjdk:21-jdk-slim
 
 LABEL maintainer "https://github.com/blacktop"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,11 +9,11 @@ if [ "$1" = 'server' ]; then
 
   # Add users
   GHIDRA_USERS=${GHIDRA_USERS:-admin}
-  if [ ! -e "/repos/users" ] && [ ! -z "${GHIDRA_USERS}" ]; then
-    mkdir -p /repos/~admin
+  if [ ! -e "/ghidra/repositories/users" ] && [ ! -z "${GHIDRA_USERS}" ]; then
+    mkdir -p /ghidra/repositories/~admin
     for user in ${GHIDRA_USERS}; do
       echo "Adding user: ${user}"
-      echo "-add ${user}" >> /repos/~admin/adm.cmd
+      echo "-add ${user}" >> /ghidra/repositories/~admin/adm.cmd
     done
   fi
 

--- a/server.conf
+++ b/server.conf
@@ -120,7 +120,7 @@ wrapper.java.maxmemory=768
 # Ghidra installation directory, although an absolute path is preferred if not using default.
 # This variable is also used by the svrAdmin script.
 
-ghidra.repositories.dir=/repos
+ghidra.repositories.dir=./repositories
 
 # Ghidra server startup parameters.
 #


### PR DESCRIPTION
Modern versions of Ghidra now require jdk 21.